### PR TITLE
Multi-version builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,9 @@ on:
 
 jobs:
   build:
-    name: Build - DuckDB ${{ matrix.duckdb_version }}
+    name: Build and test
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    strategy:
-      matrix:
-        duckdb_version:
-          - "1.1.0"
-          - "1.1.1"
-          - "1.1.2"
-          - "1.1.3"
-          - "1.2.0"
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v1
@@ -28,7 +20,6 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: false
-      - run: zig build -Dduckdb-version=${{ matrix.duckdb_version }} -Dinstall-headers --verbose --summary new
+      - run: zig build -Dinstall-headers --verbose --summary new
+      - run: zig build test -Dplatform=linux_amd64_gcc4 --summary new
       - run: tree -ash zig-out
-      - run: zig build test -Dduckdb-version=${{ matrix.duckdb_version }} -Dplatform=linux_amd64_gcc4 --summary none
-        if: ${{ matrix.duckdb_version != '1.2.0' }} # TODO: Remove once Python package is available

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ Install [Zig](https://ziglang.org) and [uv](https://docs.astral.sh/uv/). That's 
 
 Now experience the power and simplicity of the [Zig Build System](https://ziglang.org/learn/build-system/) with these commands:
 
-```
-# Build extension for all platforms (Linux, macOS, Windows)
+```shell
+# Build the extension for all supported DuckDB versions and platforms (Linux, macOS, Windows)
 zig build
 
-# Only build for a specific platform
-zig build -Dplatform=linux_amd64
+# Build for a list of DuckDB versions
+zig build -Dduckdb-version=1.1.3 -Dduckdb-version=1.2.0
 
-# Build for multiple platforms
+# Build for a list of platforms
 zig build -Dplatform=linux_arm64 -Dplatform=osx_arm64 -Dplatform=windows_arm64
 
-# Build for a specific DuckDB version
-zig build -Dduckdb-version=1.1.2
+# Build for a specific DuckDB version and platform
+zig build -Dduckdb-version=1.1.3 -Dplatform=linux_amd64
 
 # Optimize for performance
 zig build --release=fast
@@ -29,31 +29,50 @@ zig build --release=fast
 # Optimize for binary size
 zig build --release=small
 
-# Also install DuckDB C headers for development (to zig-out/include by default)
+# Also install DuckDB C headers for development
 zig build -Dinstall-headers
 ```
 
-The build output will look like this:
+The build output in `zig-out` will look like this:
 
 ```
 ❯ tree zig-out
 zig-out
-├── linux_amd64
-│   └── quack.duckdb_extension
-├── linux_amd64_gcc4
-│   └── quack.duckdb_extension
-├── linux_arm64
-│   └── quack.duckdb_extension
-├── linux_arm64_gcc4
-│   └── quack.duckdb_extension
-├── osx_amd64
-│   └── quack.duckdb_extension
-├── osx_arm64
-│   └── quack.duckdb_extension
-├── windows_amd64
-│   └── quack.duckdb_extension
-└── windows_arm64
-    └── quack.duckdb_extension
+├── v1.1.0
+│   ├── linux_amd64
+│   │   └── quack.duckdb_extension
+│   ├── linux_amd64_gcc4
+│   │   └── quack.duckdb_extension
+│   ├── linux_arm64
+│   │   └── quack.duckdb_extension
+│   ├── linux_arm64_gcc4
+│   │   └── quack.duckdb_extension
+│   ├── osx_amd64
+│   │   └── quack.duckdb_extension
+│   ├── osx_arm64
+│   │   └── quack.duckdb_extension
+│   ├── windows_amd64
+│   │   └── quack.duckdb_extension
+│   └── windows_arm64
+│       └── quack.duckdb_extension
+├── v1.1.1
+│   ├── linux_amd64
+│   │   └── quack.duckdb_extension
+│   ├── linux_amd64_gcc4
+│   │   └── quack.duckdb_extension
+│   ├── linux_arm64
+│   │   └── quack.duckdb_extension
+│   ├── linux_arm64_gcc4
+│   │   └── quack.duckdb_extension
+│   ├── osx_amd64
+│   │   └── quack.duckdb_extension
+│   ├── osx_arm64
+│   │   └── quack.duckdb_extension
+│   ├── windows_amd64
+│   │   └── quack.duckdb_extension
+│   └── windows_arm64
+│       └── quack.duckdb_extension
+├── ...
 ```
 
 See `zig build --help` for more options.
@@ -63,14 +82,26 @@ See `zig build --help` for more options.
 Run the [SQL logic tests](https://duckdb.org/docs/dev/sqllogictest/intro.html) with `zig build test`.
 
 ```
-❯ zig build test
+❯ zig build test --summary new
 [0/1] test/sql/quack.test
 SUCCESS
+[0/1] test/sql/quack.test
+SUCCESS
+[0/1] test/sql/quack.test
+SUCCESS
+[0/1] test/sql/quack.test
+SUCCESS
+Build Summary: 13/13 steps succeeded
+test success
+├─ sqllogictest v1.1.0 osx_arm64 success 95ms MaxRSS:45M
+├─ sqllogictest v1.1.1 osx_arm64 success 104ms MaxRSS:45M
+├─ sqllogictest v1.1.2 osx_arm64 success 94ms MaxRSS:43M
+└─ sqllogictest v1.1.3 osx_arm64 success 94ms MaxRSS:44M
 ```
 
 You can also pass `-Dduckdb-version` to test against a specific DuckDB version, or use `-Dplatform` to select a different native platform, e.g. `linux_amd64_gcc4` instead of `linux_amd64`.
 
-_Note: Testing is currently broken for DuckDB 1.2.0 as the duckdb Python package is not yet available._
+_Note: Testing is currently skipped for DuckDB 1.2.0 as the duckdb Python package is not yet available._
 
 ## Using the Extension
 
@@ -78,7 +109,7 @@ _Note: Testing is currently broken for DuckDB 1.2.0 as the duckdb Python package
 ❯ duckdb -unsigned
 v1.1.3 19864453f7
 Enter ".help" for usage hints.
-🟡◗ LOAD 'zig-out/osx_arm64/quack.duckdb_extension';
+🟡◗ LOAD 'zig-out/v1.1.3/osx_arm64/quack.duckdb_extension';
 🟡◗ SELECT quack('Zig');
 ┌──────────────┐
 │ quack('Zig') │
@@ -88,63 +119,19 @@ Enter ".help" for usage hints.
 └──────────────┘
 ```
 
-## Advanced: Creating an Extension Repository
+## Creating an Extension Repository
 
-You can easily create your own [extension repository](https://duckdb.org/docs/extensions/working_with_extensions.html#creating-a-custom-repository) by providing a custom installation prefix.
+You can easily create your own [extension repository](https://duckdb.org/docs/extensions/working_with_extensions.html#creating-a-custom-repository). In fact, `zig build` already does this for you by default! However, you might also want to write files to a different directory and compress them. Here's how:
 
-Here's an example:
-
-```
+```shell
 rm -rf repo
 
-# Add more versions as needed
-for version in 1.1.3 1.2.0; do
-    zig build -Dduckdb-version=${version} --prefix repo/v${version} --release=fast
-done
+zig build --prefix repo --release=fast
 
 gzip repo/*/*/*.duckdb_extension
 ```
 
-This will generate a repository with the following structure, ready to be uploaded to S3:
-
-```
-❯ tree repo
-repo
-├── v1.1.3
-│   ├── linux_amd64
-│   │   └── quack.duckdb_extension.gz
-│   ├── linux_amd64_gcc4
-│   │   └── quack.duckdb_extension.gz
-│   ├── linux_arm64
-│   │   └── quack.duckdb_extension.gz
-│   ├── linux_arm64_gcc4
-│   │   └── quack.duckdb_extension.gz
-│   ├── osx_amd64
-│   │   └── quack.duckdb_extension.gz
-│   ├── osx_arm64
-│   │   └── quack.duckdb_extension.gz
-│   ├── windows_amd64
-│   │   └── quack.duckdb_extension.gz
-│   └── windows_arm64
-│       └── quack.duckdb_extension.gz
-└── v1.2.0
-    ├── linux_amd64
-    │   └── quack.duckdb_extension.gz
-    ├── linux_amd64_gcc4
-    │   └── quack.duckdb_extension.gz
-    ├── linux_arm64
-    │   └── quack.duckdb_extension.gz
-    ├── linux_arm64_gcc4
-    │   └── quack.duckdb_extension.gz
-    ├── osx_amd64
-    │   └── quack.duckdb_extension.gz
-    ├── osx_arm64
-    │   └── quack.duckdb_extension.gz
-    ├── windows_amd64
-    │   └── quack.duckdb_extension.gz
-    └── windows_arm64
-        └── quack.duckdb_extension.gz
-```
+This will generate a repository that is ready to be uploaded to S3 with a tool like [rclone](https://rclone.org).
 
 ## License
 

--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,11 @@ const DuckDBVersion = enum {
     @"1.1.3",
     @"1.2.0",
 
-    const default: DuckDBVersion = .@"1.1.3";
+    const all = std.enums.values(DuckDBVersion);
+
+    fn string(self: DuckDBVersion, b: *Build) []const u8 {
+        return b.fmt("v{s}", .{@tagName(self)});
+    }
 
     fn headers(self: DuckDBVersion, b: *Build) ?Build.LazyPath {
         return switch (self) {
@@ -37,7 +41,7 @@ const Platform = enum {
 
     const all = std.enums.values(Platform);
 
-    fn name(self: Platform) [:0]const u8 {
+    fn string(self: Platform) [:0]const u8 {
         return @tagName(self);
     }
 
@@ -57,9 +61,11 @@ const Platform = enum {
 
 pub fn build(b: *Build) void {
     const optimize = b.standardOptimizeOption(.{});
-    const duckdb_version = b.option(DuckDBVersion, "duckdb-version", b.fmt("DuckDB version to build for (default: {s})", .{@tagName(DuckDBVersion.default)})) orelse DuckDBVersion.default;
+    const duckdb_versions = b.option([]const DuckDBVersion, "duckdb-version", "DuckDB version(s) to build for (default: all)") orelse DuckDBVersion.all;
     const platforms = b.option([]const Platform, "platform", "DuckDB platform(s) to build for (default: all)") orelse Platform.all;
     const install_headers = b.option(bool, "install-headers", "Install DuckDB C headers") orelse false;
+
+    const test_step = b.step("test", "Run SQL logic tests");
 
     const ext_version = v: {
         var code: u8 = undefined;
@@ -76,85 +82,91 @@ pub fn build(b: *Build) void {
         break :v std.mem.trim(u8, git_describe, " \n\r");
     };
 
-    const duckdb_headers = duckdb_version.headers(b) orelse return;
     const metadata_script = b.dependency("extension_ci_tools", .{}).path("scripts/append_extension_metadata.py");
 
-    for (platforms) |platform| {
-        const target = platform.target(b);
+    for (duckdb_versions) |duckdb_version| {
+        const version_string = duckdb_version.string(b);
+        const duckdb_headers = duckdb_version.headers(b) orelse continue;
 
-        const ext = b.addSharedLibrary(.{
-            .name = "quack",
-            .target = target,
-            .optimize = optimize,
-        });
-        ext.addCSourceFiles(.{
-            .files = &.{
-                "quack_extension.c",
-            },
-            .root = b.path("src"),
-            .flags = &cflags,
-        });
-        ext.addIncludePath(duckdb_headers);
-        ext.linkLibC();
-        ext.root_module.addCMacro("DUCKDB_EXTENSION_NAME", ext.name);
-        ext.root_module.addCMacro("DUCKDB_BUILD_LOADABLE_EXTENSION", "1");
+        for (platforms) |platform| {
+            const platform_string = platform.string();
+            const target = platform.target(b);
 
-        const filename = b.fmt("{s}.duckdb_extension", .{ext.name});
-        ext.install_name = b.fmt("@rpath/{s}", .{filename}); // macOS only
+            const ext = b.addSharedLibrary(.{
+                .name = "quack",
+                .target = target,
+                .optimize = optimize,
+            });
+            ext.addCSourceFiles(.{
+                .files = &.{
+                    "quack_extension.c",
+                },
+                .root = b.path("src"),
+                .flags = &cflags,
+            });
+            ext.addIncludePath(duckdb_headers);
+            ext.linkLibC();
+            ext.root_module.addCMacro("DUCKDB_EXTENSION_NAME", ext.name);
+            ext.root_module.addCMacro("DUCKDB_BUILD_LOADABLE_EXTENSION", "1");
 
-        const ext_path = path: {
-            const cmd = b.addSystemCommand(&.{ "uv", "run", "--python=3.12" });
-            cmd.addFileArg(metadata_script);
-            cmd.addArgs(&.{ "--extension-name", ext.name });
-            cmd.addArgs(&.{ "--extension-version", ext_version });
-            cmd.addArgs(&.{ "--duckdb-platform", platform.name() });
-            cmd.addArgs(&.{ "--duckdb-version", duckdb_version.extensionAPIVersion() });
-            cmd.addArg("--library-file");
-            cmd.addArtifactArg(ext);
-            cmd.addArg("--out-file");
-            const path = cmd.addOutputFileArg(filename);
+            const filename = b.fmt("{s}.duckdb_extension", .{ext.name});
+            ext.install_name = b.fmt("@rpath/{s}", .{filename}); // macOS only
 
-            cmd.step.name = b.fmt("add metadata {s}", .{platform.name()});
-            break :path path;
-        };
+            const ext_path = path: {
+                const cmd = b.addSystemCommand(&.{ "uv", "run", "--python=3.12" });
+                cmd.addFileArg(metadata_script);
+                cmd.addArgs(&.{ "--extension-name", ext.name });
+                cmd.addArgs(&.{ "--extension-version", ext_version });
+                cmd.addArgs(&.{ "--duckdb-platform", platform_string });
+                cmd.addArgs(&.{ "--duckdb-version", duckdb_version.extensionAPIVersion() });
+                cmd.addArg("--library-file");
+                cmd.addArtifactArg(ext);
+                cmd.addArg("--out-file");
+                const path = cmd.addOutputFileArg(filename);
 
-        const install_file = b.addInstallFileWithDir(ext_path, .{ .custom = platform.name() }, filename);
-        install_file.step.name = b.fmt("install {s}/{s}", .{ platform.name(), filename });
-        b.getInstallStep().dependOn(&install_file.step);
-
-        if (install_headers) {
-            const header_dirs = [_]Build.LazyPath{
-                duckdb_headers,
-                // Add more header directories here
+                cmd.step.name = b.fmt("metadata {s} {s}", .{ version_string, platform_string });
+                break :path path;
             };
-            for (header_dirs) |dir| {
-                b.getInstallStep().dependOn(&b.addInstallDirectory(.{
-                    .source_dir = dir,
-                    .include_extensions = &.{"h"},
-                    .install_dir = .header,
-                    .install_subdir = "",
-                }).step);
+
+            const install_file = b.addInstallFileWithDir(ext_path, .{
+                .custom = b.fmt("{s}/{s}", .{ version_string, platform_string }),
+            }, filename);
+            install_file.step.name = b.fmt("install {s} {s}", .{ version_string, platform_string });
+            b.getInstallStep().dependOn(&install_file.step);
+
+            if (install_headers) {
+                const header_dirs = [_]Build.LazyPath{
+                    duckdb_headers,
+                    // Add more header directories here
+                };
+                for (header_dirs) |dir| {
+                    b.getInstallStep().dependOn(&b.addInstallDirectory(.{
+                        .source_dir = dir,
+                        .include_extensions = &.{"h"},
+                        .install_dir = .{ .custom = version_string },
+                        .install_subdir = "include",
+                    }).step);
+                }
             }
-        }
 
-        // Run tests on native platform
-        if (b.host.result.os.tag == target.result.os.tag and
-            b.host.result.cpu.arch == target.result.cpu.arch and
-            !b.top_level_steps.contains("test")) // HACK: Avoid adding step twice, e.g. for linux_amd64 and linux_amd64_gcc4
-        {
-            const sqllogictest = b.lazyDependency("sqllogictest", .{}) orelse continue;
+            // Run tests on native platform
+            if (b.host.result.os.tag == target.result.os.tag and
+                b.host.result.cpu.arch == target.result.cpu.arch and
+                duckdb_version != .@"1.2.0") // TODO: Remove once Python package is available
+            {
+                const sqllogictest = b.lazyDependency("sqllogictest", .{}) orelse continue;
 
-            const cmd = b.addSystemCommand(&.{ "uv", "run", "--python=3.12", "--with" });
-            cmd.addFileArg(sqllogictest.path(""));
-            cmd.addArgs(&.{ "--with", b.fmt("duckdb=={s}", .{@tagName(duckdb_version)}) });
-            cmd.addArgs(&.{ "python3", "-m", "duckdb_sqllogictest" });
-            cmd.addArgs(&.{ "--test-dir", "test" });
-            cmd.addArg("--external-extension");
-            cmd.addFileArg(ext_path);
-            cmd.step.name = "sqllogictest";
+                const cmd = b.addSystemCommand(&.{ "uv", "run", "--python=3.12", "--with" });
+                cmd.addFileArg(sqllogictest.path(""));
+                cmd.addArgs(&.{ "--with", b.fmt("duckdb=={s}", .{@tagName(duckdb_version)}) });
+                cmd.addArgs(&.{ "python3", "-m", "duckdb_sqllogictest" });
+                cmd.addArgs(&.{ "--test-dir", "test" });
+                cmd.addArg("--external-extension");
+                cmd.addFileArg(ext_path);
+                cmd.step.name = b.fmt("sqllogictest {s} {s}", .{ version_string, platform_string });
 
-            const test_step = b.step("test", "Run SQL logic tests");
-            test_step.dependOn(&cmd.step);
+                test_step.dependOn(&cmd.step);
+            }
         }
     }
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,12 +7,10 @@
         .libduckdb_headers = .{
             .url = "https://github.com/mlafeldt/libduckdb-headers/archive/650b336.zip",
             .hash = "12209ebf64f45b8f6a977d5061058143c35ef996fbf0e99c949f0a5c68a1eb7fe7f8",
-            .lazy = true,
         },
         .libduckdb_1_1_3 = .{
             .url = "https://github.com/duckdb/duckdb/releases/download/v1.1.3/libduckdb-src.zip",
             .hash = "122081554b2ca7ea7fb02462dda7ec41c39ca42e6b8e663b3636ee10eb3cb86cef55",
-            .lazy = true,
         },
         .extension_ci_tools = .{
             .url = "https://github.com/duckdb/extension-ci-tools/archive/v1.1.3.zip",
@@ -22,7 +20,6 @@
         .sqllogictest = .{
             .url = "https://github.com/duckdb/duckdb-sqllogictest-python/archive/faf6f19.zip",
             .hash = "122031b7caca451caf571803926d5c10d262fd8a13c80ecfd2d1480bda1c4254693d",
-            .lazy = true,
         },
     },
     .paths = .{""},


### PR DESCRIPTION
Build and test the extension for **all** DuckDB versions by default, leveraging Zig's concurrent/cached builds.

This simplifies CI and turns `zig-out` into a ready-to-use extension repository.

Uncached `zig build` takes less than 30s on my M1 Pro, even with `--release=fast`. ⚡️

Use `zig build -Dflat -Dduckdb-version=xxx` if you prefer the old output format.